### PR TITLE
feat(site): 野马 PT 接入 AuthKey 开放 API

### DIFF
--- a/app/admin/services/site/LayuiTemplate.php
+++ b/app/admin/services/site/LayuiTemplate.php
@@ -124,7 +124,7 @@ class LayuiTemplate
             'siqi',
             'cangbaoge',
             'keepfrds' => Decorator::make([NexusPHP::class, OptionsUrlJoin::class, OptionsLimit::class], $default),
-            'yemapt' => Decorator::make([OptionsRssUrl::class], $default),
+            'yemapt' => Decorator::make([Yemapt::class, OptionsRssUrl::class], $default),
             'ttg' => Decorator::make([NexusPHP::class, OptionsLimit::class, OptionsRssUrl::class], $default),
             'redleaves', 'pter', 'pt', 'hdsky', 'ssd', 'lemonhd' => Decorator::make([NexusPHP::class, OptionsLimit::class], $default),
             'hdpost', 'monikadesign' => Decorator::make([NexusPHP::class, OptionsRsskey::class, OptionsRssUrl::class], $default),

--- a/app/admin/services/site/Yemapt.php
+++ b/app/admin/services/site/Yemapt.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace app\admin\services\site;
+
+use Ledc\Element\Decorator;
+
+/**
+ * 野马PT开放API配置
+ */
+class Yemapt extends Decorator
+{
+    /**
+     * @return string
+     */
+    public function html(): string
+    {
+        return $this->generate->html() . <<<EOF
+
+            <div class="layui-form-item">
+                <label class="layui-form-label required">AuthKey</label>
+                <div class="layui-input-block">
+                    <input type="text" name="options[authkey]" value="" required lay-verify="required" placeholder="请在野马PT个人详情页创建并填写API AuthKey" class="layui-input" lay-affix="eye">
+                </div>
+            </div>
+
+EOF;
+    }
+
+    /**
+     * 隐藏野马PT不再使用的Cookie配置项
+     */
+    public function js(): string
+    {
+        return $this->generate->js() . PHP_EOL . <<<'EOF'
+            layui.$("#cookie_required_label").closest(".layui-form-item").remove();
+EOF;
+    }
+}

--- a/composer/site-manager/src/BaseCookie.php
+++ b/composer/site-manager/src/BaseCookie.php
@@ -28,10 +28,18 @@ abstract class BaseCookie implements Processor, PaginationUriBuilder
      */
     final public function __construct(public readonly BaseDriver $baseDriver)
     {
+        $this->validateConfig();
+        $this->initialize();
+    }
+
+    /**
+     * 校验页面处理器所需的站点凭据
+     */
+    protected function validateConfig(): void
+    {
         if (empty($this->baseDriver->getConfig()->cookie)) {
             throw new InvalidArgumentException('cookie为空，无法解析HTML页面');
         }
-        $this->initialize();
     }
 
     /**

--- a/composer/site-manager/src/Cookie/CookieYemapt.php
+++ b/composer/site-manager/src/Cookie/CookieYemapt.php
@@ -3,16 +3,37 @@
 namespace Iyuu\SiteManager\Cookie;
 
 use Iyuu\SiteManager\BaseCookie;
-use Iyuu\SiteManager\Frameworks\NexusPhp\HasCookie;
+use Iyuu\SiteManager\Exception\EmptyListException;
+use Iyuu\SiteManager\Frameworks\Yemapt\HasOpenApi;
 use Iyuu\SiteManager\Spider\Pagination;
+use Iyuu\SiteManager\Spider\RouteEnum;
+use Iyuu\SiteManager\Spider\SpiderTorrents;
+use Iyuu\SiteManager\Utils;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * yemapt
- * - 凭cookie解析HTML列表页
+ * - 凭AuthKey请求开放API种子列表
  */
 class CookieYemapt extends BaseCookie
 {
-    use HasCookie, Pagination;
+    use HasOpenApi, Pagination;
+
+    /**
+     * 种子列表API
+     */
+    private const string LIST_API = 'openApi/torrent/fetchOpenTorrentList.json';
+
+    /**
+     * 列表每页数量
+     */
+    private const int PAGE_SIZE = 40;
+
+    /**
+     * 当前处理的是否为最后一页
+     */
+    private bool $lastPage = false;
 
     /**
      * 站点名称
@@ -20,11 +41,143 @@ class CookieYemapt extends BaseCookie
     public const string SITE_NAME = 'yemapt';
 
     /**
-     * 是否调试当前站点
-     * @return bool
+     * 凭AuthKey请求开放API并解析种子
+     * @param string $url
+     * @return array
+     * @throws EmptyListException
      */
-    protected function isDebugCurrent(): bool
+    public function process(string $url): array
     {
-        return true;
+        // 上一页不足 PAGE_SIZE 时，不再继续请求后续页面。
+        if ($this->lastPage) {
+            return [];
+        }
+
+        $domain = rtrim($this->getConfig()->parseDomain(), '/');
+        $page = $this->parsePage($url);
+        $torrents = $this->requestList($page);
+        if (!is_array($torrents)) {
+            throw new RuntimeException('野马PT种子列表接口data字段格式异常');
+        }
+        $this->lastPage = count($torrents) < self::PAGE_SIZE;
+
+        // 空页是正常的列表结束状态，不以异常中断爬虫命令。
+        if ([] === $torrents) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($torrents as $torrent) {
+            if (!is_array($torrent) || empty($torrent['id'])) {
+                continue;
+            }
+
+            $id = (int)$torrent['id'];
+            $length = (int)($torrent['fileSize'] ?? 0);
+            $items[] = [
+                'id' => $id,
+                'h1' => (string)($torrent['showName'] ?? ''),
+                'title' => (string)($torrent['shortDesc'] ?? ''),
+                'details' => $domain . '/#/torrent/detail/' . $id . '/',
+                'download' => '',
+                'filename' => $id . '.torrent',
+                'type' => 'free' === ($torrent['downloadPromotion'] ?? '') ? 0 : 1,
+                'time' => (string)($torrent['listingTime'] ?? ''),
+                'size' => Utils::dataSize($length),
+                'length' => $length,
+            ];
+        }
+
+        if (empty($items)) {
+            throw new EmptyListException("野马PT第{$page}页没有可用的种子数据");
+        }
+
+        SpiderTorrents::notify($items, $this->baseDriver, false);
+        return $items;
+    }
+
+    /**
+     * 野马PT开放API只接受AuthKey，不接受Cookie登录凭据
+     */
+    protected function validateConfig(): void
+    {
+        if (empty($this->getConfig()->getOptions('authkey'))) {
+            throw new InvalidArgumentException('野马PT缺少AuthKey配置');
+        }
+    }
+
+    /**
+     * 下载凭证由开放API生成，不需要Cookie
+     */
+    protected function isSpiderDownloadCookieRequired(): bool
+    {
+        return false;
+    }
+
+    /**
+     * 请求种子列表API
+     */
+    protected function requestList(int $page): mixed
+    {
+        return $this->postOpenApi(self::LIST_API, [
+            'keyword' => '',
+            'pageParam' => [
+                'current' => $page,
+                'pageSize' => self::PAGE_SIZE,
+            ],
+            'sorter' => [
+                'field' => 'listingTime',
+                'order' => 'descend',
+            ],
+        ]);
+    }
+
+    /**
+     * 当前已处理页面是否为最后一页
+     */
+    public function isLastPage(): bool
+    {
+        return $this->lastPage;
+    }
+
+    /**
+     * 从分页URI提取页码
+     */
+    private function parsePage(string $url): int
+    {
+        $query = parse_url($url, PHP_URL_QUERY);
+        if (is_string($query)) {
+            parse_str($query, $params);
+            if (isset($params['page']) && is_numeric($params['page'])) {
+                return max(1, (int)$params['page']);
+            }
+        }
+
+        return $this->firstPage();
+    }
+
+    /**
+     * 构造分页URI；page参数仅用于向process传递页码
+     */
+    public function pageUriBuilder(int $page, RouteEnum|string $route = null): string
+    {
+        $value = $route instanceof RouteEnum ? $route->value : $route;
+        return str_replace('{page}', max(1, $page), $value ?: self::LIST_API . '?page={page}');
+    }
+
+    /**
+     * API页码从1开始
+     */
+    public function firstPage(): int
+    {
+        return 1;
+    }
+
+    /**
+     * 默认抓取最新3页（最多120条）
+     */
+    public function crontabEndPage(): int
+    {
+        return 3;
     }
 }

--- a/composer/site-manager/src/Driver/DriverYemapt.php
+++ b/composer/site-manager/src/Driver/DriverYemapt.php
@@ -2,22 +2,184 @@
 
 namespace Iyuu\SiteManager\Driver;
 
+use InvalidArgumentException;
 use Iyuu\SiteManager\BaseDriver;
 use Iyuu\SiteManager\Contracts\Processor;
 use Iyuu\SiteManager\Contracts\ProcessorXml;
+use Iyuu\SiteManager\Contracts\Torrent;
+use Iyuu\SiteManager\Exception\TorrentException;
 use Iyuu\SiteManager\Frameworks\NexusPhp\HasRss;
+use Iyuu\SiteManager\Frameworks\Yemapt\HasOpenApi;
+use Iyuu\SiteManager\Spider\SpiderTorrents;
+use Ledc\Curl\Curl;
+use RuntimeException;
 
 /**
  * yemapt
  */
 class DriverYemapt extends BaseDriver implements Processor, ProcessorXml
 {
-    use HasRss;
+    use HasOpenApi, HasRss;
+
+    /**
+     * 获取API用户基本信息
+     */
+    private const string BASIC_INFO_API = 'openApi/user/fetchBasicInfo.json';
+
+    /**
+     * 根据piecesHash批量反查种子ID
+     */
+    private const string FETCH_ID_BY_PIECES_HASH_API = 'openApi/torrent/fetchTorrentIdWithPiecesHash.json';
+
+    /**
+     * 生成临时种子下载凭证
+     */
+    private const string GENERATE_DOWNLOAD_KEY_API = 'openApi/torrent/generateDownloadKey.json';
+
+    /**
+     * 使用临时凭证下载种子
+     */
+    private const string DOWNLOAD_API = 'api/torrent/download1';
 
     /**
      * 站点名称
      */
     public const string SITE_NAME = 'yemapt';
+
+    /**
+     * 校验野马PT开放API配置
+     */
+    protected function initialize(): void
+    {
+        if (empty($this->getConfig()->getOptions('authkey'))) {
+            throw new InvalidArgumentException('野马PT缺少AuthKey配置');
+        }
+    }
+
+    /**
+     * 验证AuthKey并获取当前API用户基本信息
+     */
+    public function fetchBasicInfo(): array
+    {
+        $data = $this->postOpenApi(self::BASIC_INFO_API);
+        if (!is_array($data) || empty($data['id'])) {
+            throw new RuntimeException('野马PT用户基本信息响应格式异常');
+        }
+        return $data;
+    }
+
+    /**
+     * 根据piecesHash批量反查野马PT种子ID；单次最多100个，超出时自动分批。
+     * @param string[] $piecesHashes
+     * @return array<string, int>
+     */
+    public function fetchTorrentIdsByPiecesHashes(array $piecesHashes): array
+    {
+        $normalized = [];
+        foreach ($piecesHashes as $index => $piecesHash) {
+            $piecesHash = strtolower(trim((string)$piecesHash));
+            if (!preg_match('/^[a-f0-9]{40}$/', $piecesHash)) {
+                throw new InvalidArgumentException("第{$index}个piecesHash不是40位SHA-1十六进制字符串");
+            }
+            $normalized[$piecesHash] = $piecesHash;
+        }
+
+        $result = [];
+        foreach (array_chunk(array_values($normalized), 100) as $chunk) {
+            $data = $this->postOpenApi(self::FETCH_ID_BY_PIECES_HASH_API, [
+                'piecesHashList' => $chunk,
+            ]);
+            if (!is_array($data)) {
+                throw new RuntimeException('野马PT piecesHash反查响应格式异常');
+            }
+            foreach ($data as $piecesHash => $torrentId) {
+                if (is_numeric($torrentId)) {
+                    $result[(string)$piecesHash] = (int)$torrentId;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * 获取带临时下载凭证的种子链接
+     * @throws TorrentException
+     */
+    public function downloadLink(Torrent $torrent): string
+    {
+        try {
+            $url = $this->deferredDownloadLink($torrent->torrent_id);
+            $torrent->setDownload($url, false);
+            return $url;
+        } catch (\Throwable $throwable) {
+            throw new TorrentException($throwable->getMessage(), $throwable->getCode());
+        }
+    }
+
+    /**
+     * 下载指定种子；始终先生成临时凭证，忽略旧式Cookie下载链接
+     */
+    protected function doDownload(Curl $curl, Torrent $torrent): void
+    {
+        $curl->get($this->deferredDownloadLink($torrent->torrent_id));
+    }
+
+    /**
+     * 爬虫真正需要下载种子时，才生成一次性下载链接。
+     */
+    protected function doDownloadMetadata(Curl $curl, SpiderTorrents $spiderTorrents): void
+    {
+        $spiderTorrents->download = $this->deferredDownloadLink((int)$spiderTorrents->id);
+        $curl->get($spiderTorrents->download);
+    }
+
+    /**
+     * 延迟生成下载链接：仅在IYUU查重通过、真正需要下载时申请临时凭证
+     */
+    public function deferredDownloadLink(int $torrentId): string
+    {
+        return $this->generateDownloadUrl($torrentId);
+    }
+
+    /**
+     * 调用开放API生成下载凭证，并构造不含AuthKey的下载地址
+     */
+    private function generateDownloadUrl(int $torrentId): string
+    {
+        if ($torrentId <= 0) {
+            throw new InvalidArgumentException('野马PT种子ID无效');
+        }
+
+        $downloadKey = $this->postOpenApi(self::GENERATE_DOWNLOAD_KEY_API . '?id=' . $torrentId);
+        if (!is_string($downloadKey) || '' === $downloadKey) {
+            throw new RuntimeException('生成野马PT种子下载凭证失败：接口未返回下载凭证');
+        }
+
+        $domain = rtrim($this->getConfig()->parseDomain(), '/');
+        return $domain . '/' . self::DOWNLOAD_API . '?token=' . rawurlencode($downloadKey);
+    }
+
+    /**
+     * 校验下载接口确实返回种子文件，并解析JSON业务错误
+     */
+    protected function afterDownload(Curl $curl, Torrent|SpiderTorrents $torrent): void
+    {
+        $contentType = strtolower((string)$curl->getResponseHeaders('Content-Type'));
+        $mimeType = trim(explode(';', $contentType, 2)[0]);
+        $result = json_decode(is_string($curl->response) ? $curl->response : '', true);
+        if ('application/json' === $mimeType || is_array($result)) {
+            $message = is_array($result) ? (string)($result['errorMessage'] ?? '下载接口返回JSON而不是种子文件') : '下载接口返回了无效JSON';
+            $code = is_array($result) ? (int)($result['errorCode'] ?? 0) : 0;
+            throw new RuntimeException('下载野马PT种子失败：' . $message, $code);
+        }
+
+        if ($curl->isSuccess() && 'application/x-bittorrent' !== $mimeType) {
+            throw new RuntimeException('下载野马PT种子失败：响应Content-Type不是application/x-bittorrent');
+        }
+
+        parent::afterDownload($curl, $torrent);
+    }
 
     /**
      * 提取种子ID的正则表达式

--- a/composer/site-manager/src/Frameworks/Yemapt/HasOpenApi.php
+++ b/composer/site-manager/src/Frameworks/Yemapt/HasOpenApi.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Iyuu\SiteManager\Frameworks\Yemapt;
+
+use JsonException;
+use Ledc\Curl\Curl;
+use RuntimeException;
+
+/**
+ * 野马PT开放API请求能力
+ */
+trait HasOpenApi
+{
+    /**
+     * 调用开放API的POST接口并返回ResultDTO.data
+     * @param string $uri API路径，可以包含查询参数
+     * @param array $data JSON请求体
+     */
+    protected function postOpenApi(string $uri, array $data = []): mixed
+    {
+        $domain = rtrim($this->getConfig()->parseDomain(), '/');
+        $curl = new Curl();
+        $this->getConfig()->setCurlOptions($curl);
+        $curl->setAccept('application/json')
+            ->setHeader('Authorization', (string)$this->getConfig()->getOptions('authkey'));
+        $url = $domain . '/' . ltrim($uri, '/');
+        if ([] === $data) {
+            $curl->post($url);
+        } else {
+            $curl->post($url, $data, true);
+        }
+
+        $response = is_string($curl->response) ? $curl->response : '';
+        try {
+            $result = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            if (!$curl->isSuccess()) {
+                $message = $curl->error_message ?? '网络不通或AuthKey无效';
+                throw new RuntimeException('请求野马PT开放API失败：' . $message, $curl->error_code);
+            }
+            throw new RuntimeException('野马PT开放API响应JSON解析失败：' . $exception->getMessage(), $exception->getCode());
+        }
+
+        if (!is_array($result) || !array_key_exists('success', $result)) {
+            throw new RuntimeException('野马PT开放API响应格式异常');
+        }
+
+        if (true !== $result['success']) {
+            $message = (string)($result['errorMessage'] ?? '未知错误');
+            throw new RuntimeException('野马PT开放API请求失败：' . $message, (int)($result['errorCode'] ?? 0));
+        }
+
+        if (!$curl->isSuccess()) {
+            $message = $curl->error_message ?? 'HTTP请求失败';
+            throw new RuntimeException('请求野马PT开放API失败：' . $message, $curl->error_code);
+        }
+
+        return $result['data'] ?? null;
+    }
+}

--- a/db/migrations/20260802095000_migrate_yemapt_to_open_api.php
+++ b/db/migrations/20260802095000_migrate_yemapt_to_open_api.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * 野马PT迁移到开放API鉴权
+ */
+final class MigrateYemaptToOpenApi extends AbstractMigration
+{
+    /**
+     * Change Method.
+     */
+    public function change(): void
+    {
+        if ($this->hasTable('cn_sites')) {
+            $this->execute("UPDATE `cn_sites` SET `nickname` = '野马PT', `cookie_required` = 0 WHERE `site` = 'yemapt'");
+        }
+    }
+}


### PR DESCRIPTION
## 变更说明

  将野马 PT 的站点接入方式由 Cookie 切换为官方开放 API，并使用 AuthKey 鉴权。

  ## 主要改动

  - 增加野马 PT AuthKey 配置项，不再要求 Cookie
  - 增加统一的野马 PT Open API 请求封装
  - 使用开放接口获取最新种子列表
    - 每页 40 条
    - 默认最多采集前 120 条
    - 返回不足 40 条时识别为最后一页
    - 空页正常结束，不再作为异常处理
  - 详情地址调整为：
    - `https://www.yemapt.org/#/torrent/detail/{id}/`
  - 增加延迟生成下载链接能力
    - 仅在真正需要下载种子时申请临时下载凭证
    - 避免提前生成的一次性链接失效
  - 校验种子下载响应
    - 正常响应要求 `Content-Type: application/x-bittorrent`
    - JSON 响应会提取 `errorCode` 和 `errorMessage`
  - 增加用户基本信息接口封装：
    - `POST /openApi/user/fetchBasicInfo.json`
  - 增加 `piecesHash` 批量反查种子 ID 能力
    - 单次最多提交 100 条
    - 超出后自动分批
  - 增加数据库迁移
    - 展示名称调整为“野马PT”
    - 取消 Cookie 必填标记

  ## 兼容性

  `BaseCookie` 增加了站点凭据校验扩展点。默认实现仍然检查 Cookie，现有站点行为不变；野马 PT 单独覆盖该方法并检查 AuthKey。

  其余开放 API、分页、批量反查及下载处理逻辑均封装在野马 PT 专属处理器和驱动中，没有增加针对其他站点的特殊分支。

  ## 验证情况

  - PHP 语法检查通过
  - 分页与末页识别离线验证通过
  - `piecesHash` 按 `100/100/5` 自动分批验证通过
  - 用户基本信息接口解析验证通过
  - 临时下载链接生成及 URL 编码验证通过
  - `git diff --check` 通过